### PR TITLE
Set block duration to 5min for quicker development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - '--web.enable-lifecycle'
       - '--web.enable-admin-api'
       - '--web.listen-address=:9001'
-      - '--storage.tsdb.min-block-duration=2h'
-      - '--storage.tsdb.max-block-duration=2h'
+      - '--storage.tsdb.min-block-duration=5m'
+      - '--storage.tsdb.max-block-duration=5m'
     restart: unless-stopped
     expose:
       - 9001
@@ -40,8 +40,8 @@ services:
       - '--web.enable-lifecycle'
       - '--web.enable-admin-api'
       - '--web.listen-address=:9002'
-      - '--storage.tsdb.min-block-duration=2h'
-      - '--storage.tsdb.max-block-duration=2h'
+      - '--storage.tsdb.min-block-duration=5m'
+      - '--storage.tsdb.max-block-duration=5m'
     restart: unless-stopped
     expose:
       - 9002


### PR DESCRIPTION
Given that this setup is purely for local development it should be fine to set the blocks to be cut every 5min.

Not sure if it makes sense for all local setups by default. Maybe 15m is better? 2h seems too long for testing. :)

/cc @prmsrswt @GiedriusS 