### PR TITLE
feat: replace docker-compose by docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(THANOS_BINARY):
 	@make -C "$(THANOS_SOURCE)" build
 
 .PHONY: up
-up: ## Bootstraps a docker-compose setup for local development/demo
+up: ## Bootstraps a docker compose setup for local development/demo
 up: $(THANOS_BINARY)
 	@echo ">> copying binaries to development env"
 	@rm -f ./thanos/thanos || true
@@ -25,14 +25,14 @@ up: $(THANOS_BINARY)
 	@echo ">> copying dashboards to development env"
 	@rm -f ./grafana/provisioning/dashboards/*.json
 	cp $(THANOS_SOURCE)/examples/dashboards/*.json ./grafana/provisioning/dashboards
-	docker-compose -f "$(COMPOSE_FILE)" up -d --build
+	docker compose -f "$(COMPOSE_FILE)" up -d --build
 
 .PHONY: restart
 restart: ## Rebuilds and restarts the container without building the binary
 restart:
-	docker-compose -f "$(COMPOSE_FILE)" up -d --build
+	docker compose -f "$(COMPOSE_FILE)" up -d --build
 
 .PHONY: down
-down: ## Brings down the docker-compose setup
+down: ## Brings down the docker compose setup
 down:
-	docker-compose -f "$(COMPOSE_FILE)" down
+	docker compose -f "$(COMPOSE_FILE)" down

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run a basic Thanos setup for local development using Docker and Docker Compose.
 
 ## Prerequisites
 
-- You need to have Docker and docker-compose installed on your machine.
+- You need to have Docker installed on your machine.
 - We use GNU Make to run common tasks, you need to have `make` installed on your machine. You can run `make -v` to check if it is already installed.
 - Thanos source code. The easiest way to achieve this is by cloning the Thanos git repository locally using `git clone https://github.com/thanos-io/thanos`.
 - You need to have Go installed as it is required to build Thanos.
@@ -29,10 +29,10 @@ Run a basic Thanos setup for local development using Docker and Docker Compose.
 
 ### Checking status of containers
 
-- You can run `docker-compose ps` to list all containers running.
-- Run `docker-compose logs <container-name>` to view logs for a container.
+- You can run `docker compose ps` to list all containers running.
+- Run `docker compose logs <container-name>` to view logs for a container.
 
-Refer to `docker-compose` documentation for a full overview.
+Refer to `docker compose` documentation for a full overview.
 
 ### Connecting to minio
 


### PR DESCRIPTION
Hello,

I purpose to replace docker-compose with `docker compose` because compose is now integrated into docker and it's not necessary to have an additional tool in order to launch this project.

Also, It will permit to have the new feature of docker and docker compose.

Feel free to ask any questions that you could have.